### PR TITLE
Update Dockerfile to work in April 2018

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER t0kx <t0kx@protonmail.ch>
 
 # install debian stuff
 RUN apt-get update && \
+    apt-get install -y software-propertes-common && \
+    add-apt-repository ppa:openjdk-r/ppa && \
     apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     wget curl openjdk-7-jre-headless && \


### PR DESCRIPTION
Add ppa:openjdk-r/ppa repository to sources.list, to make installation of openjdk-7-jre-headless possible.